### PR TITLE
Ian cleanup article service

### DIFF
--- a/src/app/components/articles/article-edit/article-edit.component.ts
+++ b/src/app/components/articles/article-edit/article-edit.component.ts
@@ -47,7 +47,6 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
 
 
   async edit(article) {
-    console.log(this.userInfo, article, this.key, this.article);
     if (!article.articleId) {
      const creationCheck = this.articleSvc.createArticle(this.userInfo, article, this.key);
        if (creationCheck === 'success') {


### PR DESCRIPTION
Address requested changes to article service:
1. > Add comment that watchBookmarkedArticles() seems to be making a lot of hard queries to FS which may be a costly way to go. See if optimization for fewer queries is possible

**watchBookmarked is only retrieving a list of articles the user has bookmarked which is saved in the db under userInfo/articleBookmarksPerUser/${userKey}
 , and then getting those articles. It’s not checking each article in the db. I’m not sure how to make this more efficient.** 

2. > arrayFromCollectionSnapshot() is a utility function and should be grouped at the end of file.

 **Done**

3. > createArticleRef() should be named createArticleId() and should be grouped with utility functions at the end of file
 
**Done**

4. > deleteArticeRef() actually deletes the article entirely and should be named appropriately and refactored to handle cleanup of all related article data. This function should probably never be used since we'd like to maintain history. May instead archive the article.

**deleteArticleRef is only used to cleanout abortive attempts at creating an article. It is there to delete what would be an ‘article’ that is comprised of nothing but a link to an image upload, not in fact a full article, or any of the associated meta-data (history/editor/preview). That would be done with a more specific method, and probably dealt with in cloud functions.** 


5. > createArticle() is closely related to updateArticle() and I'd rather see them adjacent. 

**Done**

6. > createArticle() returns "success" no matter what happens. Maybe wrap in try/catch block to return success or error, and could do same for updateArticle() 

**Done**

7. > UpdateArticle() doesn't seem to be adding the history item

**Adding the history item is handled by the cloud functions.** 

8. > Does createArticle() work? I think it needs to end with articleRef.set() instead of articleRef.update()

**The article is techinaly created when the image is uploaded. So createArtcile, is creating the bulk of the article, but in re the db, it’s already there, so set would overwrite the image data, hence update.**
