### PR TITLE
Article cover image cleanup

### DIFF
--- a/src/app/components/articles/article-cover-image/article-cover-image.component.html
+++ b/src/app/components/articles/article-cover-image/article-cover-image.component.html
@@ -2,9 +2,9 @@
   <h2>Main Image</h2>
   <div class="image-wrapper">
     <img *ngIf="articleCoverImageUrl"
-    src={{articleCoverImageUrl}}
+    [src]="articleCoverImageUrl"
     class="imageDisplay"
-    alt={{artilceImageAlt}}>
+    [alt]="artilceImageAlt">
   </div>
   
   <cos-upload-form [articleKey]="articleKey" ></cos-upload-form>

--- a/src/app/components/articles/article-cover-image/article-cover-image.component.ts
+++ b/src/app/components/articles/article-cover-image/article-cover-image.component.ts
@@ -14,7 +14,7 @@ export class ArticleCoverImageComponent implements OnInit, OnDestroy {
   editing: boolean;
   articleCoverImageUrl;
   artilceImageAlt;
-  articleSubscitptions: Subscription;
+  articleSubscitption: Subscription;
   constructor(private articleSvc: ArticleService, private uploadSvc: UploadService) { }
 
   ngOnInit() {
@@ -27,7 +27,7 @@ export class ArticleCoverImageComponent implements OnInit, OnDestroy {
   }
 
   subscribeToArticle(articleKey) {
-    this.articleSubscitptions =  this.articleSvc.currentArticle$.subscribe(articleData => {
+    this.articleSubscitption =  this.articleSvc.currentArticle$.subscribe(articleData => {
       if (articleData) {
          this.articleCoverImageUrl = articleData.imageUrl;
          this.artilceImageAlt = articleData.imageAlt;
@@ -36,7 +36,7 @@ export class ArticleCoverImageComponent implements OnInit, OnDestroy {
 }
   ngOnDestroy(): void {
     if (this.editing === true) {
-      this.articleSubscitptions.unsubscribe();
+      this.articleSubscitption.unsubscribe();
     }
 
   }

--- a/src/app/components/articles/article-cover-image/article-cover-image.component.ts
+++ b/src/app/components/articles/article-cover-image/article-cover-image.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, OnDestroy } from '@angular/core';
 import { ArticleService } from '../../../services/article.service';
-import { Subscription } from '../../../../../node_modules/rxjs';
+import { Subscription } from 'rxjs';
 import { UploadService } from '../../../services/upload.service';
 
 
@@ -14,38 +14,29 @@ export class ArticleCoverImageComponent implements OnInit, OnDestroy {
   editing: boolean;
   articleCoverImageUrl;
   artilceImageAlt;
-  coverImageSub: Subscription;
-  imageAltSub: Subscription;
+  articleSubscitptions: Subscription;
   constructor(private articleSvc: ArticleService, private uploadSvc: UploadService) { }
 
   ngOnInit() {
     if (this.articleKey) {
       this.subscribeToArticle(this.articleKey);
-      // think this is an artifact from previous
-      // approach. Will test on next pass.
+      // maybe remove this.
       this.editing = true;
     }
 
   }
 
   subscribeToArticle(articleKey) {
-    this.articleSvc.setCurrentArticle(articleKey);
-    this.coverImageSub =  this.articleSvc.currentArticle$.subscribe(articleData => {
+    this.articleSubscitptions =  this.articleSvc.currentArticle$.subscribe(articleData => {
       if (articleData) {
          this.articleCoverImageUrl = articleData.imageUrl;
+         this.artilceImageAlt = articleData.imageAlt;
       }
-
-    });
-    this.imageAltSub = this.articleSvc.currentArticle$.subscribe(articleData => {
-      if (articleData) {
-        this.artilceImageAlt = articleData.imageAlt;
-      }
-    });
-  }
+  });
+}
   ngOnDestroy(): void {
     if (this.editing === true) {
-      this.imageAltSub.unsubscribe();
-      this.coverImageSub.unsubscribe();
+      this.articleSubscitptions.unsubscribe();
     }
 
   }

--- a/src/app/components/articles/article-edit/article-edit.component.ts
+++ b/src/app/components/articles/article-edit/article-edit.component.ts
@@ -2,6 +2,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ArticleService } from '../../../services/article.service';
 import { UserService } from '../../../services/user.service';
 import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'cos-article-edit',
@@ -15,6 +16,7 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
   routeParams: any;
   userInfo = null;
   articleValid: boolean;
+  subscribeToCurrentArticle: Subscription;
 
 
   constructor(
@@ -33,13 +35,12 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
     this.route.params.subscribe(params => {
       if (params) {
         this.key = params['key'];
-        this.articleSvc
-        .getArticleById(this.key).then(articleToEdit => {
-          if (articleToEdit) {
+        this.articleSvc.setCurrentArticle(this.key);
+        this.subscribeToCurrentArticle = this.articleSvc.currentArticle$.subscribe(articleData => {
+          if (articleData) {
+            this.article = articleData;
             this.articleValid = true;
-            this.article = articleToEdit;
           }
-          this.article = articleToEdit;
         });
       }
     });
@@ -62,7 +63,7 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
     console.log('this.article', this.article);
     console.log('this.articleValid', this.articleValid);
     console.log('this.key', this.key);
-
+    this.subscribeToCurrentArticle.unsubscribe();
     if (!this.article && !this.articleValid) {
       this.articleSvc.deleteArticleRef(this.key);
     }

--- a/src/app/components/articles/article-edit/article-edit.component.ts
+++ b/src/app/components/articles/article-edit/article-edit.component.ts
@@ -16,7 +16,7 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
   routeParams: any;
   userInfo = null;
   articleValid: boolean;
-  subscribeToCurrentArticle: Subscription;
+  currentArticleSubscription: Subscription;
 
 
   constructor(
@@ -36,7 +36,7 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
       if (params) {
         this.key = params['key'];
         this.articleSvc.setCurrentArticle(this.key);
-        this.subscribeToCurrentArticle = this.articleSvc.currentArticle$.subscribe(articleData => {
+        this.currentArticleSubscription = this.articleSvc.currentArticle$.subscribe(articleData => {
           if (articleData) {
             this.article = articleData;
             this.articleValid = true;
@@ -63,7 +63,7 @@ export class ArticleEditComponent implements OnInit, OnDestroy {
     console.log('this.article', this.article);
     console.log('this.articleValid', this.articleValid);
     console.log('this.key', this.key);
-    this.subscribeToCurrentArticle.unsubscribe();
+    this.currentArticleSubscription.unsubscribe();
     if (!this.article && !this.articleValid) {
       this.articleSvc.deleteArticleRef(this.key);
     }


### PR DESCRIPTION
Address changes:

> Property binding syntax should be as noted in PR # 18 for both [src] and [alt] 

**Done**

> Imports from node_modules change as in PR#18 notes 

**Done**

> I'm not sure if you had this too but I'm still not able to create or edit at this point…

**Not there yet in this process. The actual in-refactor branch has all the functionality in place.** 

> When subscribing to article here, is it necessary to setCurrentArticle() first? Should this ever be used in a situation where there's no current article (e.g. outside the article edit or save)?

**Removed call to setCurrentArticle in cover-image.ts. Add it to edit-article.ts onInit, and subscription cleanup method onDestroy.**

> It looks like we're creating two subscptions to currentArticle$ but only need one. That is, you should be able to set both articlCoverImageUrl and articleImageAlt in the same subscription.

**Done**
