### PR TITLE
Image size standardization

### DIFF
--- a/src/app/components/articles/article-edit/cover-image-display/cover-image-display.component.scss
+++ b/src/app/components/articles/article-edit/cover-image-display/cover-image-display.component.scss
@@ -26,5 +26,9 @@
     max-width: 100%;
     display: block;
     margin: 0 auto;
+
+    @media screen and (min-width: 500px) {
+      height: 466px;
+    }
   }
 }

--- a/src/app/components/articles/article-edit/cover-image-display/cover-image-display.component.scss
+++ b/src/app/components/articles/article-edit/cover-image-display/cover-image-display.component.scss
@@ -30,5 +30,9 @@
     @media screen and (min-width: 500px) {
       height: 466px;
     }
+
+    @media screen and (max-width: 499px) {
+      max-height: 350px;
+    }
   }
 }

--- a/src/app/components/articles/article-edit/cover-image-display/cover-image-display.component.ts
+++ b/src/app/components/articles/article-edit/cover-image-display/cover-image-display.component.ts
@@ -18,5 +18,5 @@ export class CoverImageDisplayComponent implements OnInit {
 
   toggleCtrl = () => {
     this.onCtrlToggle.emit();
-  };
+  }
 }


### PR DESCRIPTION
Set a standard image size for the article title image to avoid the rapid image reformatting that happens on initial page load and to prevent extremely tall images from hurting the UX. This is for large screens only, mobile still needs to be addressed but more dynamically.